### PR TITLE
Fix links on non-default port (and not https)

### DIFF
--- a/features/metrics-api.feature
+++ b/features/metrics-api.feature
@@ -9,10 +9,10 @@ Feature: Metrics API
     When I send a GET request to "metrics"
     Then the response status should be "200"
     And the JSON response should have "$.metrics[0].name" with the text "membership-count"
-    And the JSON response should have "$.metrics[0].url" with the text "https://example.org/metrics/membership-count.json"
+    And the JSON response should have "$.metrics[0].url" with the text "http://example.org/metrics/membership-count.json"
     And the JSON response should have "$.metrics[1].name" with the text "membership-coverage"
-    And the JSON response should have "$.metrics[1].url" with the text "https://example.org/metrics/membership-coverage.json"
-    
+    And the JSON response should have "$.metrics[1].url" with the text "http://example.org/metrics/membership-coverage.json"
+
   Scenario: POSTing structured data
     Given I authenticate as the user "foo" with the password "bar"
     When I send a POST request to "metrics/membership-coverage" with the following:

--- a/lib/metrics-api.rb
+++ b/lib/metrics-api.rb
@@ -59,7 +59,7 @@ class MetricsApi < Sinatra::Base
       "metrics" => Metric.all.distinct(:name).sort.map do |name|
         {
           name: name,
-          url: "https://#{request.host}/metrics/#{name}.json"
+          url: "#{request.base_url}/metrics/#{name}.json"
         }
       end
     }


### PR DESCRIPTION
When I run locally, all the links appear as `https://localhost/*` regardless of the port I’m using. This fixes that.