### PR TITLE
Make configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 
 /coverage/
 /dump/
+.powrc
+tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,13 @@ env:
     - secure: pl5TWg1MBYYwn0U6bvpcIzs0XoXjrEkn8YmkwKHu4XMXJ0LDHjzQp5/6NVROa5BKntHXLzi+rFRO1csZVuDcEOqE/cKKwEJzZ/k68XURod3gWDYS+m6n9JosAH8h43BHE4H+8oe7I/HCsSfakE0s+dN131VuZvAUlYlU3gGxn9Y=
     - secure: ccMcTlK/AXhp4t1rxZdZ/UomAt5uaJ6AERitrQRbNijeS7HxMCjAe/XM99NJX98/Vp55chWq0M1SJwjb9RnGSJ0zuhTzIzYZ/eHaPzMiKA3ntvKBbJCuqcSeGTkOBieBa6xICqlvAepPLrw5/c9mWa1ILvr9oeHQeHnBkh5LWdM=
     - secure: pcWqFi7kfMGvC9OcVeMtAlFqSYak9pvLuihxCm3gxJ8sEvnt6FEO7NsJYq/bdcqol6aAON89P1t+oPDoGEr5VZgHiDksb57HtunOA51veMTncMm/EnY1sHWgIVr/DV9kNBtWAu12NDxR8nFm6wENXCPKR1vXZLIrVhNnpQjo4Tw=
+    - METRICS_API_TITLE='ODI Metrics'
+    - METRICS_API_DESCRIPTION='This API contains a list of all metrics collected by the Open Data Institute since 2013'
+    - METRICS_API_LICENSE_NAME='Creative Commons Attribution-ShareAlike'
+    - METRICS_API_LICENSE_URL='https://creativecommons.org/licenses/by-sa/4.0/'
+    - METRICS_API_PUBLISHER_NAME='Open Data Institute'
+    - METRICS_API_PUBLISHER_URL='http://theodi.org'
+    - METRICS_API_CERTIFICATE_URL='https://certificates.theodi.org/en/datasets/213482/certificate/badge.js'
 deploy:
   - provider: heroku
     api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
     - METRICS_API_LICENSE_URL='https://creativecommons.org/licenses/by-sa/4.0/'
     - METRICS_API_PUBLISHER_NAME='Open Data Institute'
     - METRICS_API_PUBLISHER_URL='http://theodi.org'
-    - METRICS_API_CERTIFICATE_URL='https://certificates.theodi.org/en/datasets/213482/certificate/badge.js'
+    - METRICS_API_CERTIFICATE_URL='https://certificates.theodi.org/en/datasets/213482/certificate'
 deploy:
   - provider: heroku
     api_key:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 A simple wrapper around MongoDB to allow storage of time series metrics.
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 ## Content negotiation
 
 The API will respond to the following _Accept_ values with appropriate content:

--- a/app.json
+++ b/app.json
@@ -1,22 +1,57 @@
 {
-  "name": "metrics-api",
+  "name": "Metrics API",
+  "description": "A simple wrapper around MongoDB to allow storage of time series metrics.",
+  "keywords": [
+    "data",
+    "metrics",
+    "visualisations"
+  ],
+  "website": "http://metrics.theodi.org/",
+  "repository": "https://github.com/theodi/metrics-api",
+  "logo": "https://avatars0.githubusercontent.com/u/2492770?v=3&s=200",
+  "success_url": "/metrics",
   "scripts": {
   },
   "env": {
-    "LANG": {
+    "METRICS_API_TITLE": {
+      "description": "The title of your Metrics API instance - i.e. 'My Awesome Metrics'",
       "required": true
     },
-    "METRICS_API_BASE_URL": {
+    "METRICS_API_DESCRIPTION": {
+      "description": "The description for your Metrics API instance",
       "required": true
     },
-    "METRICS_API_PASSWORD": {
+    "METRICS_API_LICENSE_NAME": {
+      "description": "The name of license you are releasing your data under - see http://licenses.opendefinition.org/#all-licenses for a list",
+      "required": true
+    },
+    "METRICS_API_LICENSE_URL": {
+      "description": "The url of license you are releasing your data under - see http://licenses.opendefinition.org/#all-licenses for a list",
+      "required": true
+    },
+    "METRICS_API_PUBLISHER_NAME": {
+      "description": "The name of the organisation who is publishing this data",
+      "required": true
+    },
+    "METRICS_API_PUBLISHER_URL": {
+      "description": "The website of the organisation who is publishing this data",
+      "required": true
+    },
+    "METRICS_API_CERTIFICATE_URL": {
+      "description": "The URL of the Open Data Certificate for your data",
       "required": true
     },
     "METRICS_API_USERNAME": {
+      "description": "The username you will need to provide when adding metrics",
+      "required": true
+    },
+    "METRICS_API_PASSWORD": {
+      "description": "The password you will need to provide when adding metrics",
       "required": true
     },
     "RACK_ENV": {
-      "required": true
+      "required": true,
+      "value": "production"
     }
   },
   "addons": [

--- a/lib/metrics-api.rb
+++ b/lib/metrics-api.rb
@@ -67,6 +67,7 @@ class MetricsApi < Sinatra::Base
     respond_to do |wants|
 
       wants.html do
+        @config = config
         @title = 'Metrics API'
         erb :index, layout: 'layouts/default'.to_sym
       end
@@ -84,6 +85,8 @@ class MetricsApi < Sinatra::Base
         }
       end
     }
+
+    @config = config
 
     respond_to do |wants|
       wants.json { @metrics.to_json }

--- a/lib/metrics-api/helpers.rb
+++ b/lib/metrics-api/helpers.rb
@@ -70,6 +70,22 @@ module Helpers
     end
   end
 
+  def config
+    {
+      title: ENV['METRICS_API_TITLE'],
+      description: ENV['METRICS_API_DESCRIPTION'],
+      license: {
+        name: ENV['METRICS_API_LICENSE_NAME'],
+        url: ENV['METRICS_API_LICENSE_URL']
+      },
+      publisher: {
+        name: ENV['METRICS_API_PUBLISHER_NAME'],
+        url: ENV['METRICS_API_PUBLISHER_URL']
+      },
+      certificate_url: ENV['METRICS_API_CERTIFICATE_URL']
+    }
+  end
+
 end
 
 class String

--- a/lib/metrics-api/helpers.rb
+++ b/lib/metrics-api/helpers.rb
@@ -76,7 +76,8 @@ module Helpers
       description: ENV['METRICS_API_DESCRIPTION'],
       license: {
         name: ENV['METRICS_API_LICENSE_NAME'],
-        url: ENV['METRICS_API_LICENSE_URL']
+        url: ENV['METRICS_API_LICENSE_URL'],
+        image: license_image(ENV['METRICS_API_LICENSE_URL'])
       },
       publisher: {
         name: ENV['METRICS_API_PUBLISHER_NAME'],
@@ -84,6 +85,15 @@ module Helpers
       },
       certificate_url: ENV['METRICS_API_CERTIFICATE_URL']
     }
+  end
+
+  def license_image(url)
+    match = url.match /https?:\/\/creativecommons.org\/licenses\/([a-z\-]+)\/([0-9\.]+)/
+    if match
+      "https://licensebuttons.net/l/#{match[1]}/#{match[2]}/88x31.png"
+    else
+      nil
+    end
   end
 
 end

--- a/lib/views/layouts/default.erb
+++ b/lib/views/layouts/default.erb
@@ -12,9 +12,11 @@
         <div class='col-md-3'>
           <script src='<%= @config[:certificate_url] %>/badge.js'></script>
           <hr />
-          <a href='https://creativecommons.org/licenses/by-sa/4.0/' title='Creative Commons Attribution ShareAlike 4.0'>
-            <img alt='Creative Commons License' style='border-width:0' src='https://i.creativecommons.org/l/by-sa/4.0/88x31.png' />
-          </a>
+          <% if @config[:license][:image] %>
+            <a href='<%= @config[:license][:url] %>' title='<%= @config[:license][:title] %>'>
+              <img alt='Creative Commons License' style='border-width:0' src='<%= @config[:license][:image] %>' />
+            </a>
+          <% end %>
           <hr />
         </div>
       </div>

--- a/lib/views/layouts/default.erb
+++ b/lib/views/layouts/default.erb
@@ -10,7 +10,7 @@
           <%= yield %>
         </div>
         <div class='col-md-3'>
-          <script src='https://certificates.theodi.org/en/datasets/213482/certificate/badge.js'></script>
+          <script src='<%= @config[:certificate_url] %>'></script>
           <hr />
           <a href='https://creativecommons.org/licenses/by-sa/4.0/' title='Creative Commons Attribution ShareAlike 4.0'>
             <img alt='Creative Commons License' style='border-width:0' src='https://i.creativecommons.org/l/by-sa/4.0/88x31.png' />

--- a/lib/views/layouts/default.erb
+++ b/lib/views/layouts/default.erb
@@ -10,7 +10,7 @@
           <%= yield %>
         </div>
         <div class='col-md-3'>
-          <script src='<%= @config[:certificate_url] %>'></script>
+          <script src='<%= @config[:certificate_url] %>/badge.js'></script>
           <hr />
           <a href='https://creativecommons.org/licenses/by-sa/4.0/' title='Creative Commons Attribution ShareAlike 4.0'>
             <img alt='Creative Commons License' style='border-width:0' src='https://i.creativecommons.org/l/by-sa/4.0/88x31.png' />

--- a/lib/views/metrics.erb
+++ b/lib/views/metrics.erb
@@ -4,9 +4,9 @@
             foaf: http://xmlns.com/foaf/0.1/'>
   <div typeof='dcat:Dataset' resource='<%= request.url %>'>
 
-    <h1 property='dct:title'>ODI Metrics</h1>
+    <h1 property='dct:title'><%= @config[:title] %></h1>
     <div property='dct:description'>
-      <p>This API contains a list of all metrics collected by the Open Data Institute since 2013</p>
+      <p><%= @config[:description] %></p>
     </div>
 
     <p>
@@ -19,8 +19,8 @@
 
     <h2>License</h2>
 
-      <div property='dct:license' resource='https://creativecommons.org/licenses/by-sa/4.0/'>
-        <p>This data is licensed under the <a href='https://creativecommons.org/licenses/by-sa/4.0/'><span property='dct:title'>Creative Commons Attribution-ShareAlike</span></a> License</p>
+      <div property='dct:license' resource='<%= @config[:license][:url] %>'>
+        <p>This data is licensed under the <a href='<%= @config[:license][:url] %>'><span property='dct:title'><%= @config[:license][:name] %></span></a> License</p>
 
       </div>
 
@@ -45,9 +45,9 @@
       <dd property='dct:modified' content='<%= @updated.iso8601 %>' datatype='xsd:dateTime'><%= @updated.strftime('%B %e %Y at %H:%I') %></dd>
 
       <dt>Published by</dt>
-      <dd property='dct:publisher' resource='http://theodi.org'>
-        <a href='http://theodi.org' about='http://theodi.org' property='foaf:homepage'>
-          <span property='foaf:name'>Open Data Institute</span>
+      <dd property='dct:publisher' resource='<%= @config[:publisher][:url] %>'>
+        <a href='<%= @config[:publisher][:url] %>' about='<%= @config[:publisher][:url] %>' property='foaf:homepage'>
+          <span property='foaf:name'><%= @config[:publisher][:name] %></span>
         </a>
       </dd>
 

--- a/spec/helpers/helpers_spec.rb
+++ b/spec/helpers/helpers_spec.rb
@@ -51,6 +51,16 @@ describe Helpers do
       '2013 Q1 Completed Tasks'
     )
   end
+
+  it 'gets a image url for a creative commons license' do
+    image = helpers.license_image('https://creativecommons.org/licenses/cc-by/4.0/')
+    expect(image).to eq('https://licensebuttons.net/l/cc-by/4.0/88x31.png')
+  end
+
+  it 'returns nil for a non cc license' do
+    image = helpers.license_image('http://www.opendefinition.org/licenses/against-drm')
+    expect(image).to eq(nil)
+  end
 end
 
 describe String do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-
 ENV['RACK_ENV'] = 'test'
 
 require 'metrics-api'
@@ -7,6 +6,9 @@ require 'rack/test'
 require 'webmock/rspec'
 require 'database_cleaner'
 DatabaseCleaner.strategy = :truncation
+
+require 'dotenv'
+Dotenv.load
 
 class TestHelper
   include Helpers


### PR DESCRIPTION
This allows anyone to deploy their own Metrics API via a magic Heroku deploy button.

<a href="https://heroku.com/deploy"><img src="https://www.herokucdn.com/deploy/button.png" alt="Deploy" data-canonical-src="https://www.herokucdn.com/deploy/button.svg" style="max-width:100%;"></a>

Shiny!