### PR TITLE
Get metric name from params

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ using a JSON content type, and with the following JSON in the body:
 
 ```
 {
-  "name": "{metric-name}",
   "time": "{iso8601-date-time}",
   "value": ...
 }

--- a/features/metrics-api.feature
+++ b/features/metrics-api.feature
@@ -18,7 +18,6 @@ Feature: Metrics API
     When I send a POST request to "metrics/membership-coverage" with the following:
       """
       {
-        "name": "membership-coverage",
         "time": "2013-12-25T15:00:00+00:00",
         "value": {
                   "health": 0.33,
@@ -40,7 +39,6 @@ Feature: Metrics API
     When I send a POST request to "metrics/membership-count" with the following:
       """
       {
-        "name": "membership-count",
         "time": "2013-12-25T15:00:00+00:00",
         "value": 10
       }

--- a/features/metrics-api.feature
+++ b/features/metrics-api.feature
@@ -167,3 +167,22 @@ Feature: Metrics API
       """
     Then the response status should be "400"
     And there should be 0 defaults with the type "membership-count"
+
+
+  Scenario: POSTing data in a legacy format
+    Given I authenticate as the user "foo" with the password "bar"
+    When I send a POST request to "metrics/membership-count" with the following:
+      """
+      {
+        "name": "membership-count",
+        "time": "2013-12-25T15:00:00+00:00",
+        "value": 10
+      }
+      """
+    Then the response status should be "201"
+    And the data should be stored in the "membership-count" metric
+    And the time of the stored metric should be "2013-12-25T15:00:00+00:00"
+    And the value of the metric should be:
+      """
+      10
+      """

--- a/lib/metrics-api.rb
+++ b/lib/metrics-api.rb
@@ -106,7 +106,16 @@ class MetricsApi < Sinatra::Base
 
   post '/metrics/:metric' do
     protected!
-    @metric = Metric.new(JSON.parse request.body.read)
+
+    body = JSON.parse request.body.read
+
+    metric =
+
+    @metric = Metric.new({
+      "name" => params[:metric],
+      "time" => body["time"],
+      "value" => body["value"]
+    })
 
     if @metric.save
       return 201


### PR DESCRIPTION
There was duplication before, so this means we only have the metric name in one place